### PR TITLE
Add altsync option for helix_core_client plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,35 @@
 
 **Topics**
 
-- <a href="#v1-0-5">v1\.0\.5</a>
+- <a href="#v1-0-6">v1\.0\.6</a>
     - <a href="#release-summary">Release Summary</a>
     - <a href="#minor-changes">Minor Changes</a>
+- <a href="#v1-0-5">v1\.0\.5</a>
+    - <a href="#release-summary-1">Release Summary</a>
+    - <a href="#minor-changes-1">Minor Changes</a>
 
-<a id="v1-0-5"></a>
-## v1\.0\.5
+<a id="v1-0-6"></a>
+## v1\.0\.6
 
 <a id="release-summary"></a>
 ### Release Summary
 
-Updated the collection metadata URLs and added docs
+Fix helix\_core\_client idempotency for 23\.1 or newer
 
 <a id="minor-changes"></a>
+### Minor Changes
+
+* helix\_core\_client \- Check for noaltsync option when creating clients on Helix Core 23\.1 or newer
+
+<a id="v1-0-5"></a>
+## v1\.0\.5
+
+<a id="release-summary-1"></a>
+### Release Summary
+
+Updated the collection metadata URLs and added docs
+
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * docs \- Generated HTML documentation for modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Ripclawffb.Helix\_Core Release Notes
 
 .. contents:: Topics
 
+v1.0.6
+======
+
+Release Summary
+---------------
+
+Fix helix_core_client idempotency for 23.1 or newer
+
+Minor Changes
+-------------
+
+- helix_core_client - Check for noaltsync option when creating clients on Helix Core 23.1 or newer
+
 v1.0.5
 ======
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+To contribute to this project, you'll need access to a Perforce server for testing.
+
+To setup your environment you'll need to run `pipenv install`, `pipenv shell`
+
+To install a collection from a branch run:
+
+`ansible-galaxy collection install git+https://github.com/ripclawffb/ansible-collection-helix-core.git,<branch_name>`
+
+To run Ansible playbook, run: `ansible-playbook -i inventory playbook.yml`
+
+Example inventory:
+
+```
+localhost-py3 ansible_host=localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+
+[py3-hosts]
+localhost
+
+[py3-hosts:vars]
+ansible_python_interpreter=/usr/bin/python3
+```
+
+Example test playbook you can use for testing. If developing a new module replace or add a task to use that module.
+
+```
+- hosts: all
+
+  collections:
+    - ripclawffb.helix_core
+
+  tasks:
+    - name: Set auth.id for any server id
+      helix_core_configurable:
+        state: present
+        name: auth.id
+        value: master.1
+        p4port: '1666'
+        p4user: ''
+        p4passwd: ''
+        p4charset: none
+    - name: Create a new server spec
+      helix_core_server:
+        state: present
+        description: Created by user.
+        archivedatafilter:
+            - //depot1/...
+            - -//depot2/...
+        revisiondatafilter:
+            - //depot1/...
+            - -//depot2/...
+        serverid: edge
+        services: edge-server
+        type: server
+        server: '1666'
+        p4user: ''
+        p4passwd: ''
+        charset: none
+    - name: Create a edge server spec
+      helix_core_server:
+        state: present
+        description: Created by user.
+        externaladdress: 127.0.0.1
+        archivedatafilter:
+            - //depot1/...
+            - -//depot2/...
+        revisiondatafilter:
+            - //depot1/...
+            - -//depot2/...
+        serverid: edge2
+        services: edge-server
+        type: server
+        server: '1666'
+        p4user: ''
+        p4passwd: ''
+        charset: none
+    - name: Create a new group
+      helix_core_group:
+        state: present
+        name: xyz
+        users:
+            - root
+        server: '1666'
+        p4user: ''
+        p4passwd: ''
+        charset: none
+```

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -7,3 +7,9 @@ releases:
       minor_changes:
         - docs - Generated HTML documentation for modules
         - urls - Update URLs for the collection
+  1.0.6:
+    release_date: '2024-04-22'
+    changes:
+      release_summary: Fix helix_core_client idempotency for 23.1 or newer
+      minor_changes:
+        - helix_core_client - Check for noaltsync option when creating clients on Helix Core 23.1 or newer

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,7 @@ tags:
   - perforce
   - p4
   - p4d
-version: 1.0.5
+version: 1.0.6
 homepage: 'https://galaxy.ansible.com/ui/repo/published/ripclawffb/helix_core/'
 build_ignore:
   - '.cache'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -39,14 +39,14 @@ platforms:
     dockerfile: Dockerfile.rockylinux.8-22.2.j2
     image: rockylinux.8-22.2
     command: '-r .'
-  # - name: rockylinux8-23.1
-  #   dockerfile: Dockerfile.rockylinux.8-23.1.j2
-  #   image: rockylinux.8-23.1
-  #   command: '-r .'
-  # - name: rockylinux8-23.2
-  #   dockerfile: Dockerfile.rockylinux.8-23.2.j2
-  #   image: rockylinux.8-23.2
-  #   command: '-r .'
+  - name: rockylinux8-23.1
+    dockerfile: Dockerfile.rockylinux.8-23.1.j2
+    image: rockylinux.8-23.1
+    command: '-r .'
+  - name: rockylinux8-23.2
+    dockerfile: Dockerfile.rockylinux.8-23.2.j2
+    image: rockylinux.8-23.2
+    command: '-r .'
   - name: rockylinux9-22.1
     dockerfile: Dockerfile.rockylinux.9-22.1.j2
     image: rockylinux.9-22.1
@@ -55,14 +55,14 @@ platforms:
     dockerfile: Dockerfile.rockylinux.9-22.2.j2
     image: rockylinux.9-22.2
     command: '-r .'
-  # - name: rockylinux9-23.1
-  #   dockerfile: Dockerfile.rockylinux.9-23.1.j2
-  #   image: rockylinux.9-23.1
-  #   command: '-r .'
-  # - name: rockylinux9-23.2
-  #   dockerfile: Dockerfile.rockylinux.9-23.2.j2
-  #   image: rockylinux.9-23.2
-  #   command: '-r .'
+  - name: rockylinux9-23.1
+    dockerfile: Dockerfile.rockylinux.9-23.1.j2
+    image: rockylinux.9-23.1
+    command: '-r .'
+  - name: rockylinux9-23.2
+    dockerfile: Dockerfile.rockylinux.9-23.2.j2
+    image: rockylinux.9-23.2
+    command: '-r .'
   # - name: ubuntu1804-20.2
   #   dockerfile: Dockerfile.ubuntu.18.04-20.2.j2
   #   image: ubuntu:18.04-20.2
@@ -103,30 +103,30 @@ platforms:
     dockerfile: Dockerfile.ubuntu.20.04-22.2.j2
     image: ubuntu:20.04-22.2
     command: '-r .'
-  # - name: ubuntu2004-23.1
-  #   dockerfile: Dockerfile.ubuntu.20.04-23.1.j2
-  #   image: ubuntu:20.04-23.1
-  #   command: '-r .'
-  # - name: ubuntu2004-23.2
-  #   dockerfile: Dockerfile.ubuntu.20.04-23.2.j2
-  #   image: ubuntu:20.04-23.2
-  #   command: '-r .'
-  # - name: ubuntu2204-22.1
-  #   dockerfile: Dockerfile.ubuntu.22.04-22.1.j2
-  #   image: ubuntu:22.04-22.1
-  #   command: '-r .'
+  - name: ubuntu2004-23.1
+    dockerfile: Dockerfile.ubuntu.20.04-23.1.j2
+    image: ubuntu:20.04-23.1
+    command: '-r .'
+  - name: ubuntu2004-23.2
+    dockerfile: Dockerfile.ubuntu.20.04-23.2.j2
+    image: ubuntu:20.04-23.2
+    command: '-r .'
+  - name: ubuntu2204-22.1
+    dockerfile: Dockerfile.ubuntu.22.04-22.1.j2
+    image: ubuntu:22.04-22.1
+    command: '-r .'
   - name: ubuntu2204-22.2
     dockerfile: Dockerfile.ubuntu.22.04-22.2.j2
     image: ubuntu:22.04-22.2
     command: '-r .'
-  # - name: ubuntu2204-23.1
-  #   dockerfile: Dockerfile.ubuntu.22.04-23.1.j2
-  #   image: ubuntu:22.04-23.1
-  #   command: '-r .'
-  # - name: ubuntu2204-23.2
-  #   dockerfile: Dockerfile.ubuntu.22.04-23.2.j2
-  #   image: ubuntu:22.04-23.2
-  #   command: '-r .'
+  - name: ubuntu2204-23.1
+    dockerfile: Dockerfile.ubuntu.22.04-23.1.j2
+    image: ubuntu:22.04-23.1
+    command: '-r .'
+  - name: ubuntu2204-23.2
+    dockerfile: Dockerfile.ubuntu.22.04-23.2.j2
+    image: ubuntu:22.04-23.2
+    command: '-r .'
   # - name: ubuntu2404-22.1
   #   dockerfile: Dockerfile.ubuntu.24.04-22.1.j2
   #   image: ubuntu:24.04-22.1

--- a/plugins/modules/helix_core_client.py
+++ b/plugins/modules/helix_core_client.py
@@ -224,6 +224,11 @@ def run_module():
             # check to see if any fields have changed
             if 'Access' in p4_client_spec:
 
+                # detect noaltsync option (available in Helix Core 23.1 and later)
+                # required for idempotency for Helix Core 23.1 or newer
+                if 'noaltsync' in p4_client_spec["Options"]:
+                    module.params['options'] = f'{module.params["options"]} noaltsync'
+
                 p4_client_changes = []
                 p4_client_changes.append(p4_client_spec["Description"].rstrip() == module.params['description'])
                 p4_client_changes.append(p4_client_spec["Host"] == module.params['host'])


### PR DESCRIPTION
There is a new `altsync` option in Helix Core clients starting with version 23.1. To maintain `helix_core_client` compatibility with older Helix Core versions and idempotency in newer versions, I have to detect if `noaltsync` is listed in the client options.